### PR TITLE
Add setter for customer's email invoicing address

### DIFF
--- a/library/Xi/Netvisor/Resource/Xml/CustomerBaseInformation.php
+++ b/library/Xi/Netvisor/Resource/Xml/CustomerBaseInformation.php
@@ -13,6 +13,7 @@ class CustomerBaseInformation
     private $phonenumber;
     private $email;
     private $isprivatecustomer = 1;
+    private $emailinvoicingaddress;
 
     /**
      * @param string $name
@@ -52,6 +53,23 @@ class CustomerBaseInformation
     public function setEmail($email)
     {
         $this->email = $email;
+        return $this;
+    }
+
+    /**
+     * @param string $email
+     * @return self
+     */
+    public function setEmailInvoicingAddress($email)
+    {
+        /**
+         * Sets the email invoicing address if the given email is valid.
+         * Netvisor API rejects invalid email addresses, so they are ignored.
+         */
+        if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $this->emailinvoicingaddress = $email;
+        }
+
         return $this;
     }
 

--- a/tests/Xi/Netvisor/Resource/Xml/CustomerTest.php
+++ b/tests/Xi/Netvisor/Resource/Xml/CustomerTest.php
@@ -68,6 +68,22 @@ class CustomerTest extends XmlTestCase
         $this->assertXmlContainsTagWithValue('email', $email, $xml);
     }
 
+    public function testSetEmailInvoicingAddress()
+    {
+        $email = 'asdf@asdf.fi';
+        $this->baseInformation->setEmailInvoicingAddress($email);
+        $xml = $this->toXml($this->customer->getSerializableObject());
+        $this->assertXmlContainsTagWithValue('emailinvoicingaddress', $email, $xml);
+    }
+
+    public function testSetEmailInvoicingAddressWithInvalidEmailAddress()
+    {
+        $email = 'asdfasdf.fi';
+        $this->baseInformation->setEmailInvoicingAddress($email);
+        $xml = $this->toXml($this->customer->getSerializableObject());
+        $this->assertXmlDoesNotContainTag('emailinvoicingaddress', $email, $xml);
+    }
+
     /**
      * @dataProvider businessIdProvider
      */


### PR DESCRIPTION
The method ignores invalid email addresses because the Netvisor API requires a valid email format for the 'emailinvoicingaddress' field.

Includes tests for both valid and invalid cases.